### PR TITLE
Refactor: Improve Playwright config and base URL handling

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -125,7 +125,7 @@ export default defineConfig({
     // {
     //   name: 'Microsoft Edge',
     //   use: { ...devices['Desktop Edge'], channel: 'msedge', storageState: '.auth/user.json' },
-    //   dependencies: ['Webkit'],
+    //   dependencies: ['setup'],
     // },
     // {
     //   name: 'Google Chrome',

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -3,8 +3,8 @@ import * as dotenv from 'dotenv';
 dotenv.config({ override: true });
 
 export class Configuration {
-  public static get baseUrl(): string {
-    return process.env.BASE_URL ?? '[NOT SET]';
+  public static get baseUrl(): string | undefined {
+    return process.env.BASE_URL;
   }
   public static get user(): string {
     return process.env.USER_STANDARD ?? '[NOT SET]';


### PR DESCRIPTION
- Modified `src/config/configuration.ts` for the `baseUrl` getter to return `string | undefined`. This ensures that the fallback mechanism in `playwright.config.ts` correctly uses the default URL when `BASE_URL` environment variable is not set.
- Corrected the dependency for the commented-out 'Microsoft Edge' project in `playwright.config.ts` from `['Webkit']` to `['setup']` for consistency with other browser setups.